### PR TITLE
Display clear-night icon if the time is between sunset and sunrise

### DIFF
--- a/examples/TFT_eSPI_weather/TFT_eSPI_weather.ino
+++ b/examples/TFT_eSPI_weather/TFT_eSPI_weather.ino
@@ -529,7 +529,7 @@ const char* getMeteoconIcon(uint8_t iconIndex)
 {
   if (iconIndex > MAX_ICON_INDEX) iconIndex = 0; // 0 = unknown
   if (iconIndex == 7) iconIndex = 4; // Change partly-cloudy-night to clear-day
-  if( iconIndex == 4 && current->time > daily->sunsetTime[0] && current->time < daily->sunriseTime[1]) iconIndex = 5;
+  if (iconIndex == 4 && current->time > daily->sunsetTime[0] && current->time < daily->sunriseTime[1]) iconIndex = 5;
   return dsw.iconName(iconIndex);
 }
 

--- a/examples/TFT_eSPI_weather/TFT_eSPI_weather.ino
+++ b/examples/TFT_eSPI_weather/TFT_eSPI_weather.ino
@@ -529,6 +529,7 @@ const char* getMeteoconIcon(uint8_t iconIndex)
 {
   if (iconIndex > MAX_ICON_INDEX) iconIndex = 0; // 0 = unknown
   if (iconIndex == 7) iconIndex = 4; // Change partly-cloudy-night to clear-day
+  if( iconIndex == 4 && current->time > daily->sunsetTime[0] && current->time < daily->sunriseTime[1]) iconIndex = 5;
   return dsw.iconName(iconIndex);
 }
 


### PR DESCRIPTION
I've implemented heavily modified version of this (along with fetching of air quality API) as a weather station in my home, found this bug by accident. clear-sky icon is never used in the current code and displays clear-day at night time :)

Thank you for the library @Bodmer !